### PR TITLE
require exact match for redirects

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -11,9 +11,15 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$      $1.html [END]
 
-Redirect 301 /downloads             https://akka.io/try-akka/
-Redirect 301 /news/all-news.html    https://akka.io/blog/news-archive.html
-Redirect 301 /releases/             https://akka.io/blog/tags.html#releases-ref
-Redirect 301 /news                  https://akka.io/blog/
-Redirect 301 /blog/news             https://akka.io/blog/
-Redirect 301 /presentations-blogs   https://akka.io/blog/external-archive.html
+#
+# This file version controlled at
+# https://github.com/akka/akka.io/blob/master/.htaccess
+#
+
+Redirect 301 /downloads                      https://akka.io/try-akka
+Redirect 301 /news/all-news.html             https://akka.io/blog/news-archive.html
+Redirect 301 /releases                       https://akka.io/blog/tags.html#releases-ref
+Redirect 301 /presentations-blogs            https://akka.io/blog/external-archive.html
+
+RedirectMatch 301 ^/news/?$                  https://akka.io/blog/
+RedirectMatch 301 ^/blog/news/?$             https://akka.io/blog/

--- a/.htaccess
+++ b/.htaccess
@@ -18,8 +18,8 @@ RewriteRule ^(.*)$      $1.html [END]
 
 Redirect 301 /downloads                      https://akka.io/try-akka
 Redirect 301 /news/all-news.html             https://akka.io/blog/news-archive.html
-Redirect 301 /releases                       https://akka.io/blog/tags.html#releases-ref
 Redirect 301 /presentations-blogs            https://akka.io/blog/external-archive.html
 
+RedirectMatch 301 ^/releases/?.*             https://akka.io/blog/tags.html#releases-ref
 RedirectMatch 301 ^/news/?$                  https://akka.io/blog/
 RedirectMatch 301 ^/blog/news/?$             https://akka.io/blog/


### PR DESCRIPTION
As it turns out `Redirect` applies to all paths starting with the given URL.
https://httpd.apache.org/docs/2.4/mod/mod_alias.html#redirect

This requires exaxct match for some redirects to apply.