### PR TITLE
Don't mark Akka 2.5 'outdated'

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -51,7 +51,6 @@ layout: null
     },
     "2.5": {
       "latest": "{{ page.previous_akka_version }}",
-      "outdated": true,
       "instead": "2.6"
     },
     "2.6": {


### PR DESCRIPTION
The 'outdated' marking leads the warning: "This version of Akka is
outdated and not supported! Please upgrade to version 2.6.5 as soon
as possible.

That is too strong for Akka 2.5. Leaving the 'instead' so we can later
update `warnOldDocs.js` to add a milder warning pointing people to
2.6.