### PR TITLE
Adds a breakline after video widget

### DIFF
--- a/_includes/youtubePlayer.html
+++ b/_includes/youtubePlayer.html
@@ -1,3 +1,4 @@
 <div class="yt-widget" id="yt-{{ include.id }}">
 	<a href="https://www.youtube.com/watch?v={{ include.id }}" target="_blank" >Watch the video on YouTube</a>
+	<br/>
 </div>


### PR DESCRIPTION
I notices that there is no spacing between the video and the next text. This will add some spacing. 