### PR TITLE
fix links under the assumption that all posts have been moved to category "article"

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -32,3 +32,6 @@ Redirect 301 /presentations-blogs            https://akka.io/blog/external-archi
 RedirectMatch 301 ^/releases/?.*             https://akka.io/blog/tags.html#releases-ref
 RedirectMatch 301 ^/news/?$                  https://akka.io/blog/
 RedirectMatch 301 ^/blog/news/?$             https://akka.io/blog/
+
+# some posts used to have no category but were now moved to "article"
+RedirectMatch 301 ^/blog/(20.*)$             https://akka.io/blog/article/$1


### PR DESCRIPTION
It seems remaining posts have been moved to category "article" in
50e81f67bc29cf2803b9cc57818a8b5d9d5aeb4b..

One of those posts is now under `/blog/news` (2019-02-04-programming-reactive-systems)
so for this one the redirect will be wrong.

Refs #756
