### PR TITLE
upgrade cookie banner and preference center for CCPA

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -1,5 +1,5 @@
 <!-- Disqus Comments -->
-<div id="disqus_thread"><div class="cookie-warning"><p>Cookies are required for this functionality.<a class="optanon-allow-all">Allow Cookies</a><p></div></div>
+<div id="disqus_thread"><div class="cookie-warning"><p>Cookies are required for this functionality.<a class="optanon-allow-all" onclick="OneTrust.AllowAll();">Allow Cookies</a><p></div></div>
 <script type="text/plain" class="optanon-category-4">
     (function() {  // DON'T EDIT BELOW THIS LINE
         var d = document, s = d.createElement('script');

--- a/_includes/footermenu.html
+++ b/_includes/footermenu.html
@@ -1,6 +1,6 @@
 <footer>
   <div class="row">
-    <div class="sevencol">
+    <div class="eightcol">
       <div class="footerLinks">
         <ul>
           <h2>Akka</h2>
@@ -28,7 +28,7 @@
         <a class="bright optanon-toggle-display">Cookie Settings</a>
       </p>
     </div>
-    <div class="fivecol">
+    <div class="fourcol">
       <img class="footerLogo desktop-only" src="{{ site.baseurl }}/resources/images/akka_icon_reverse.svg" />
     </div>
   </div>

--- a/_includes/headerbottom.html
+++ b/_includes/headerbottom.html
@@ -1,6 +1,6 @@
-    <!-- OneTrust Cookies Consent Notice (Production Standard, akka.io, en-GB) start -->
-    <script src="https://optanon.blob.core.windows.net/consent/159bb13d-6748-4399-806e-ac28db879785.js" type="text/javascript" charset="UTF-8"></script> 
-    <!-- OneTrust Cookies Consent Notice (Production Standard, akka.io, en-GB) end -->
+    <!-- OneTrust Cookies Consent Notice start for akka.io -->
+    <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="28b912e7-09e9-43d5-91e4-3d1897044004" ></script>
+    <!-- OneTrust Cookies Consent Notice end for akka.io -->
     
     <!--Google Analytics & Google Tag Manager-->
     <script type="text/plain" class="optanon-category-2">

--- a/cookie/index.html
+++ b/cookie/index.html
@@ -19,7 +19,7 @@ title: Cookie Listing
     <div class="ninecol">
       <h1>Your Privacy</h1>
       <p>When you visit any web site, it may store or retrieve information on your browser, mostly in the form of cookies. This information might be about you, your preferences or your device and is mostly used to make the site work as you expect it to. The information does not usually directly identify you, but it can give you a more personalised web experience.</p>
-      <p>Because we respect your right to privacy, you <a class="optanon-toggle-display">can choose</a> not to allow some types of cookies. Below is a list of the cookies that get set on the akka.io domain. Blocking some types of cookies may impact your experience of the site and the services we are able to offer.</p>
+      <p>Because we respect your right to privacy, you <a onclick="OneTrust.ToggleInfoDisplay();">can choose</a> not to allow some types of cookies. Below is a list of the cookies that get set on the akka.io domain. Blocking some types of cookies may impact your experience of the site and the services we are able to offer.</p>
       <p><a class="optanon-toggle-display btn">COOKIE SETTINGS</a></p>
       <br><hr><br>
       <h1>Cookie Listing</h1>

--- a/resources/javascript/akka-io.js
+++ b/resources/javascript/akka-io.js
@@ -105,8 +105,8 @@ function OptanonWrapper() {
         //remove the prepended yt- from the ID. The ID is prepended with yt- so that we don't break old html4 clients that can't have IDs that begin with numbers.
         var ytID = widget.attr("id").slice(3);
         //swap out link with allow cookies dialogue
-        widget.html('<div class="cookie-warning video-warning"><p>To watch this video in page.<a class="optanon-allow-all">Allow Cookies</a><br><small>Alternatively you can <a class="link" href="https://www.youtube.com/watch?v='+ytID+'" target="_blank">watch on YouTube</a>.</small></p></div>');
+        widget.html('<div class="cookie-warning video-warning"><p>To watch this video in page.<a class="optanon-allow-all" onclick="OneTrust.AllowAll();">Allow Cookies</a><br><small>Alternatively you can <a class="link" href="https://www.youtube.com/watch?v='+ytID+'" target="_blank">watch on YouTube</a>.</small></p></div>');
         //load youtube player if cookies are approved
-        Optanon.InsertHtml('<div class="tubeytube"><iframe src="//www.youtube.com/embed/'+ytID+'?rel=0&modestbranding=0" frameborder="0" allow="fullscreen"></iframe></div>', 'yt-'+ytID, null, {deleteSelectorContent: true}, 4);
+        OneTrust.InsertHtml('<div class="tubeytube"><iframe src="//www.youtube.com/embed/'+ytID+'?rel=0&modestbranding=0" frameborder="0" allow="fullscreen"></iframe></div>', 'yt-'+ytID, null, {deleteSelectorContent: true}, '4');
     }); 
 };

--- a/resources/stylesheets/sass/modules/_oneTrust.scss
+++ b/resources/stylesheets/sass/modules/_oneTrust.scss
@@ -1,120 +1,42 @@
-body .optanon-alert-box-wrapper .optanon-alert-box-bottom-top {
-	height: 20px
+body #onetrust-pc-sdk .ot-switch {
+    width: 45px !important;
+    padding: 0 !important;
 }
-body .optanon-alert-box-wrapper .optanon-alert-box-bottom-padding {
-	padding-bottom: 20px
+body #onetrust-pc-sdk .ot-switch-nob:before  {
+    transform: translateX(2px); 
 }
-.lightbend-privacy-cookie-footer {
-	padding: 1rem 0 1rem 0; 
-	color: white;
-	vertical-align: middle;
-	p {
-		font-size: 0.875rem;
-		vertical-align: middle;
-	}
-	.optanon-show-settings-wrapper {
-		display: inline-block;
-		vertical-align: middle;
-	}
+body .onetrust-pc-dark-filter {
+    background: rgba(0,0,0,.75);
 }
-.optanon-cookie-policy-group {
-	padding-top: 4rem;
-	&:first-child {
-		padding-top: 0;
-	}
+body #onetrust-button-group {
+    display: flex !important;
+    flex-direction: row-reverse !important;
+    justify-content: flex-end !important;
+    text-align: left !important;
 }
-.optanon-cookie-policy-group-name {
-	font-weight: 700;
-	margin-bottom: .5rem
+body #onetrust-accept-btn-handler {
+    opacity: 1 !important;
+    transition: all 300ms ease-in-out;
+    outline: none !important;
 }
-.optanon-cookie-policy-subgroup-table-column-header {
-	font-weight: 700;
+body #onetrust-pc-sdk #close-pc-btn-handler.ot-close-icon {
+    outline: none !important;
 }
-.cookie-warning {
-	background: #6cc04a;
-	display: inline-block;
-	margin: 1rem 0;
-	padding: 1rem;
-	font-weight: 700;
-	border-radius: 3px;
-	text-align: center;
-	p {
-		color: white !important;
-		font-size: 1rem !important;
-		margin: 0;
-	
-		> a {
-			border: 1px solid white;
-			color: white;
-			display: inline-block;
-			padding: .25rem .5rem;
-			text-decoration: none;
-			margin: .25rem .5rem;
-			cursor: pointer;
-			&:hover {
-				background: rgba(white, .6);
-				color: #6cc04a;
-			}
-		}
-		> a.link {
-			border: none;
-			color: white;
-			display: inline;
-			padding: 0;
-			text-decoration: underline;
-			margin: 0;
-			cursor: pointer;
-			&:hover {
-				background: none;
-				color: white;
-			}
-		}
-	}
-	small {
-		color: white !important;
-		font-size: .75rem !important;
-		margin-top: .5rem;
-		display: inline-block;
-		opacity: .9;
-		> a.link {
-			border: none;
-			color: white;
-			display: inline;
-			padding: 0;
-			text-decoration: underline;
-			font-size: .75rem !important;
-			margin: 0;
-			cursor: pointer;
-			&:hover {
-				background: none;
-				color: #366025;
-			}
-		}
-	}
+body #onetrust-accept-btn-handler:hover {
+    background-color: $pri_blue !important;
+    border-color: $pri_blue !important;
+    transition: all 300ms ease-in-out;
 }
-.cookie-warning.video-warning{
-	text-align: left;
+body .ot-pc-footer-logo {
+    display: none;
 }
-.flex-video {
-	background-color: lb-off-white-dkr;
-	text-align: center;
-	.cookie-warning {
-		background: transparent;
-		padding: .5rem 2rem;
-		margin: 2rem auto 0 auto;
-		p {
-			color: lgm-purple !important;
-			> a {
-				display: block;
-				margin: 1rem auto;
-				max-width: 300px;
-				border: 1px solid lgm-purple;
-				color: lgm-purple;
-				&:hover {
-					background: lgm-purple-dkr;
-					color: white;
-				}
-			}
-		}
-  	}
+body #onetrust-pc-sdk .ot-cat-grp .ot-always-active {
+    color: #6cc04a;
+}
+body #onetrust-pc-sdk .ot-tgl input:checked+.ot-switch .ot-switch-nob {
+    border-color: #6cc04a;
+    background-color: #d4e8cb;
+}
+body #onetrust-pc-sdk .ot-tgl input:checked+.ot-switch .ot-switch-nob:before {
+    background-color: #6cc04a;
 }


### PR DESCRIPTION
@ennru @patriknw 

This updates the akka.io website to the latest cookie banner code. It uses geo-location to present Californian users with CCPA specific language in the preference center, cookie banner and footer link. The rest the world see's existing GDPR messaging. I'll be sending over a PR for the Akka Docs also.

Also the preference center and cookie banner has a new look and feel as part of this upgrade, that all visitors will now see. 

Example of the Preference center newer look:
![akka-preference-center](https://user-images.githubusercontent.com/1418129/104231514-f101e380-5403-11eb-8c38-1f34b473ca20.png)


In California, the `Cookie Settings` link in the footer is automatically replaced with a `Do Not Sell My Personal Information` per CCPA. As a result of the longer link, I needed to tweak the footer column sizes.

![akka-footer](https://user-images.githubusercontent.com/1418129/104231657-23abdc00-5404-11eb-926c-328901be4bca.png)





