### PR TITLE
Show Akka Products on /docs page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -34,25 +34,70 @@ title: Documentation
     </div>
 </section>
 
-<section class="wrapper getStarted">
-  <div class="row">
-    <div class="sixcol">
-      <h1>Getting started</h1>
-      <p>New to Akka, want to get up and running and learn the basics as fast as possible? Check out the get started section of the documentation!</p>
+<section class="wrapper docModules">
+    <div class="row">
+        <div class="twelvecol">
+            <h1>Akka Products</h1>
+        </div>
     </div>
-    <div class="threecol">
-      <a class="btn getStartedBtn scala" href="https://doc.akka.io/docs/akka/current/typed/guide/introduction.html?language=scala">Get started Scala</a>
+    <div class="row">
+        <div class="docModuleGrid">
+            <div class="box single-column">
+                <h1>Akka Serverless</h1>
+                <span class="underLine"></span>
+                <p>
+                    Build stateful, high performance, back-end services and APIs on a powerful serverless PaaS.
+                </p>
+                <div class="docMeta">
+                    <div>
+                        <h2>Java, Javascript,<br/>more coming</h2>
+                    </div>
+                    <div class="docMetaContent">
+                        <a href="https://developer.lightbend.com/docs/akka-serverless/index.html">Documentation</a>
+                        <a href="https://console.akkaserverless.com/p/register">Free Trial</a>
+                    </div>
+                </div>
+            </div>
+            <div class="box single-column">
+                <h1>Akka Cloud Platform<br/>for AWS</h1>
+                <span class="underLine"></span>
+                <p>
+                    The full power of Akka Platform on AWS, including Telemetry and pay-as-you-go billing.
+                </p>
+                <div class="docMeta">
+                    <div>
+                        <h2>Java and Scala</h2>
+                    </div>
+                    <div class="docMetaContent">
+                        <a href="https://developer.lightbend.com/docs/akka-platform-guide/deployment/aws-index.html">Documentation</a>
+                        <a href="https://aws.amazon.com/marketplace/pp/prodview-cfpp7sft2d6mi">AWS&nbsp;Marketplace</a>
+                    </div>
+                </div>
+            </div>
+            <div class="box single-column">
+                <h1>Akka Cloud Platform<br/>for GCP</h1>
+                <span class="underLine"></span>
+                <p>
+                    The full power of Akka Platform on GCP, including Telemetry and pay-as-you-go billing.
+                </p>
+                <div class="docMeta">
+                    <div>
+                        <h2>Java and Scala</h2>
+                    </div>
+                    <div class="docMetaContent">
+                        <a href="https://developer.lightbend.com/docs/akka-platform-guide/deployment/gcp-install.html">Documentation</a>
+                        <a href="https://console.cloud.google.com/marketplace/product/lightbend-public/akka-cloud-platform">GCP&nbsp;Marketplace</a>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
-    <div class="threecol">
-      <a class="btn getStartedBtn java" href="https://doc.akka.io/docs/akka/current/typed/guide/introduction.html?language=java">Get started Java</a>
-    </div>
-  </div>
 </section>
 
 <section class="wrapper docModules">
   <div class="row">
     <div class="twelvecol">
-      <h1>Akka Modules</h1>
+      <h1>Akka OSS Modules</h1>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
The "Getting Started" section doesn't really fit when we add the cloud products.

We'll work on the "Try Akka" page to divert users depending on the way the want to hakk.﻿
